### PR TITLE
Add check for initialized items, fix #5

### DIFF
--- a/src/VirtualList.svelte
+++ b/src/VirtualList.svelte
@@ -60,7 +60,7 @@
 	let items = [];
 
 	let state = {
-		offset:             scrollOffset || (scrollToIndex != null && getOffsetForIndex(scrollToIndex)) || 0,
+		offset:             scrollOffset || (scrollToIndex != null && items.length && getOffsetForIndex(scrollToIndex)) || 0,
 		scrollChangeReason: SCROLL_CHANGE_REASON.REQUESTED,
 	};
 

--- a/test/VirtualList.spec.js
+++ b/test/VirtualList.spec.js
@@ -9,4 +9,9 @@ test('renders successfully', () => {
 	expect(container).toBeInTheDocument();
 });
 
+test('scrollToIndexTest', () => {
+	const { container } = render(VirtualList, { height: 600, itemCount: 1000, itemSize: 50, scrollToIndex: 20 });
+	expect(container).toBeInTheDocument();
+});
+
 /* TODO: Add tests */


### PR DESCRIPTION
Add check mentioned in #5. Add simple test for use-case with `scrollToIndex` defined, which fails without fix.