### PR TITLE
fix: correct detail props of `itemsUpdated`

### DIFF
--- a/src/VirtualList.svelte
+++ b/src/VirtualList.svelte
@@ -222,8 +222,8 @@
 			}
 
 			dispatchEvent('itemsUpdated', {
-				startIndex: start,
-				stopIndex:  stop,
+				start,
+				end:  stop,
 			});
 		}
 


### PR DESCRIPTION
Hi @Skayo, thank you for this great library!

I found `itemsUpdated` return `startIndex` & `stopIndex` instead of `start` & `end`.
So I changed the props to match `index.d.ts` and your doc.